### PR TITLE
ARROW-40088: use exported_symbols_list on macOS

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -354,20 +354,27 @@ include(SetupCxxFlags)
 # Linker flags
 #
 
-# Localize thirdparty symbols using a linker version script. This hides them
-# from the client application. The OS X linker does not support the
-# version-script option.
+# Localize thirdparty symbols using a linker version script (or an exported
+# symbols list on macOS). This hides them from the client application.
 if(CMAKE_VERSION VERSION_LESS 3.18)
-  if(APPLE OR WIN32)
+  if(WIN32)
     set(CXX_LINKER_SUPPORTS_VERSION_SCRIPT FALSE)
   else()
     set(CXX_LINKER_SUPPORTS_VERSION_SCRIPT TRUE)
   endif()
 else()
   include(CheckLinkerFlag)
-  check_linker_flag(CXX
-                    "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/src/arrow/symbols.map"
-                    CXX_LINKER_SUPPORTS_VERSION_SCRIPT)
+  if(APPLE)
+    check_linker_flag(
+      CXX
+      "-Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/src/arrow/exported_symbols.list"
+      CXX_LINKER_SUPPORTS_VERSION_SCRIPT)
+  else()
+    check_linker_flag(
+      CXX
+      "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/src/arrow/symbols.map"
+      CXX_LINKER_SUPPORTS_VERSION_SCRIPT)
+  endif()
 endif()
 
 #

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -1013,8 +1013,13 @@ else()
 endif()
 
 if(CXX_LINKER_SUPPORTS_VERSION_SCRIPT)
-  set(ARROW_VERSION_SCRIPT_FLAGS
-      "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
+  if(APPLE)
+    set(ARROW_VERSION_SCRIPT_FLAGS
+        "-Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/exported_symbols.list")
+  else()
+    set(ARROW_VERSION_SCRIPT_FLAGS
+        "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
+  endif()
   set(ARROW_SHARED_LINK_FLAGS ${ARROW_VERSION_SCRIPT_FLAGS})
 endif()
 

--- a/cpp/src/arrow/exported_symbols.list
+++ b/cpp/src/arrow/exported_symbols.list
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+*arrow*
+*arrow_vendored*
+*opentelemetry*
+_arrow_*
+_Arrow*
+_descriptor_table_Flight*_2eproto

--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -142,8 +142,13 @@ endif()
 #   endforeach()
 # endif()
 if(CXX_LINKER_SUPPORTS_VERSION_SCRIPT)
-  string(APPEND GANDIVA_SHARED_LINK_FLAGS
-         " -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
+  if(APPLE)
+    string(APPEND GANDIVA_SHARED_LINK_FLAGS
+           " -Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/exported_symbols.list")
+  else()
+    string(APPEND GANDIVA_SHARED_LINK_FLAGS
+           " -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
+  endif()
 endif()
 
 add_arrow_lib(gandiva

--- a/cpp/src/gandiva/exported_symbols.list
+++ b/cpp/src/gandiva/exported_symbols.list
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+*gandiva*
+*opentelemetry*

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -280,8 +280,13 @@ if(ARROW_WITH_OPENTELEMETRY)
 endif()
 
 if(CXX_LINKER_SUPPORTS_VERSION_SCRIPT)
-  set(PARQUET_SHARED_LINK_FLAGS
-      "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
+  if(APPLE)
+    set(PARQUET_SHARED_LINK_FLAGS
+        "-Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/exported_symbols.list")
+  else()
+    set(PARQUET_SHARED_LINK_FLAGS
+        "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
+  endif()
 endif()
 
 add_arrow_lib(parquet

--- a/cpp/src/parquet/exported_symbols.list
+++ b/cpp/src/parquet/exported_symbols.list
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+*parquet*
+_arrow_*
+_parquet_*
+*opentelemetry*


### PR DESCRIPTION
## Summary
- handle macOS symbol visibility via exported_symbols_list
- add exported symbol lists for Arrow, Parquet, and Gandiva

## Testing
- `pre-commit run --files cpp/CMakeLists.txt cpp/src/arrow/CMakeLists.txt cpp/src/arrow/exported_symbols.list cpp/src/parquet/CMakeLists.txt cpp/src/parquet/exported_symbols.list cpp/src/gandiva/CMakeLists.txt cpp/src/gandiva/exported_symbols.list` *(failed: command not found)*
- `cd cpp && mkdir build && cd build && cmake .. -GNinja -DARROW_MIMALLOC=OFF` 
- `ninja arrow_shared` *(failed: could not download xsimd)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fdb76b388333867806b7a13b704b