### PR TITLE
ARROW-40088: Use exported symbols list on macOS

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -354,20 +354,27 @@ include(SetupCxxFlags)
 # Linker flags
 #
 
-# Localize thirdparty symbols using a linker version script. This hides them
-# from the client application. The OS X linker does not support the
-# version-script option.
+# Localize third-party symbols using a linker version script. This hides them
+# from the client application. The macOS linker does not support the
+# GNU "version-script" option but allows providing exported or unexported
+# symbol lists instead. Treat this capability as equivalent for our purposes.
 if(CMAKE_VERSION VERSION_LESS 3.18)
-  if(APPLE OR WIN32)
+  if(WIN32)
     set(CXX_LINKER_SUPPORTS_VERSION_SCRIPT FALSE)
   else()
     set(CXX_LINKER_SUPPORTS_VERSION_SCRIPT TRUE)
   endif()
 else()
-  include(CheckLinkerFlag)
-  check_linker_flag(CXX
-                    "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/src/arrow/symbols.map"
-                    CXX_LINKER_SUPPORTS_VERSION_SCRIPT)
+  if(APPLE)
+    # ld64 doesn't understand --version-script but supports exported symbols
+    # lists, which we use below.
+    set(CXX_LINKER_SUPPORTS_VERSION_SCRIPT TRUE)
+  else()
+    include(CheckLinkerFlag)
+    check_linker_flag(CXX
+                      "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/src/arrow/symbols.map"
+                      CXX_LINKER_SUPPORTS_VERSION_SCRIPT)
+  endif()
 endif()
 
 #

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -1013,8 +1013,13 @@ else()
 endif()
 
 if(CXX_LINKER_SUPPORTS_VERSION_SCRIPT)
-  set(ARROW_VERSION_SCRIPT_FLAGS
-      "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
+  if(APPLE)
+    set(ARROW_VERSION_SCRIPT_FLAGS
+        "-Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/symbols.list")
+  else()
+    set(ARROW_VERSION_SCRIPT_FLAGS
+        "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
+  endif()
   set(ARROW_SHARED_LINK_FLAGS ${ARROW_VERSION_SCRIPT_FLAGS})
 endif()
 

--- a/cpp/src/arrow/symbols.list
+++ b/cpp/src/arrow/symbols.list
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Exported symbol patterns for libarrow on macOS.
+__Z*arrow*
+__Z*arrow_vendored*
+__Z*opentelemetry*
+_arrow_*
+_Arrow*
+_descriptor_table_Flight*_2eproto

--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -142,8 +142,13 @@ endif()
 #   endforeach()
 # endif()
 if(CXX_LINKER_SUPPORTS_VERSION_SCRIPT)
-  string(APPEND GANDIVA_SHARED_LINK_FLAGS
-         " -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
+  if(APPLE)
+    string(APPEND GANDIVA_SHARED_LINK_FLAGS
+           " -Wl,-unexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/symbols.list")
+  else()
+    string(APPEND GANDIVA_SHARED_LINK_FLAGS
+           " -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
+  endif()
 endif()
 
 add_arrow_lib(gandiva

--- a/cpp/src/gandiva/symbols.list
+++ b/cpp/src/gandiva/symbols.list
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Symbols to hide from libgandiva on macOS.
+__cxa_*
+__once_proxy
+__Z*std*
+__Z*std::__once_call*

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -280,8 +280,13 @@ if(ARROW_WITH_OPENTELEMETRY)
 endif()
 
 if(CXX_LINKER_SUPPORTS_VERSION_SCRIPT)
-  set(PARQUET_SHARED_LINK_FLAGS
-      "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
+  if(APPLE)
+    set(PARQUET_SHARED_LINK_FLAGS
+        "-Wl,-unexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/symbols.list")
+  else()
+    set(PARQUET_SHARED_LINK_FLAGS
+        "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
+  endif()
 endif()
 
 add_arrow_lib(parquet

--- a/cpp/src/parquet/symbols.list
+++ b/cpp/src/parquet/symbols.list
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Symbols to hide from libparquet on macOS.
+__cxa_*
+__once_proxy
+__Z*boost*
+__Z*apache*thrift*
+__Z*std*
+__Z*std::__once_call*


### PR DESCRIPTION
## Summary
- support macOS linker by using exported/unexported symbol lists
- add symbol list files for arrow, parquet, and gandiva

## Testing
- `pre-commit run --files cpp/CMakeLists.txt cpp/src/arrow/CMakeLists.txt cpp/src/parquet/CMakeLists.txt cpp/src/gandiva/CMakeLists.txt cpp/src/arrow/symbols.list cpp/src/parquet/symbols.list cpp/src/gandiva/symbols.list` *(command failed: pre-commit: not found)*
- `pip install pre-commit` *(command failed: Could not find a version that satisfies the requirement pre-commit)*
- `cmake -S cpp -B build -GNinja -DARROW_PARQUET=OFF -DARROW_GANDIVA=OFF -DARROW_CSV=OFF -DARROW_DATASET=OFF -DARROW_IPC=OFF -DARROW_JEMALLOC=OFF -DARROW_WITH_BROTLI=OFF -DARROW_WITH_LZ4=OFF -DARROW_WITH_SNAPPY=OFF -DARROW_WITH_ZLIB=OFF -DARROW_WITH_ZSTD=OFF -DARROW_BUILD_TESTS=OFF`
- `ninja -C build arrow_shared` *(command failed: Command failed (1): '/usr/bin/cmake' '-P' '/workspace/arrow/build/mimalloc_ep-prefix/src/mimalloc_ep-stamp/download-mimalloc_ep.cmake')*

------
https://chatgpt.com/codex/tasks/task_e_68a3fdb76b388333867806b7a13b704b