### PR TITLE
Restore CMake module path after ThirdpartyToolchain

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -517,6 +517,11 @@ set(PARQUET_PC_REQUIRES_PRIVATE "")
 
 include(ThirdpartyToolchain)
 
+# ThirdpartyToolchain may modify CMAKE_MODULE_PATH; ensure Arrow's module
+# directory remains at the front so subsequent includes can locate our
+# CMake modules.
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules")
+
 # Add common flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_COMMON_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARROW_CXXFLAGS}")


### PR DESCRIPTION
## Summary
- Re-prepend Arrow's cmake_modules directory to CMAKE_MODULE_PATH after including ThirdpartyToolchain so san-config and other modules remain discoverable

## Testing
- `cmake -S cpp -B cpp/build`
- `pre-commit run --files cpp/CMakeLists.txt` *(fails: Executable `Rscript` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4370c0c308333b35655e02b3fe0f6